### PR TITLE
refactor(index.js): call to new outside of module

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -277,10 +277,6 @@ process.on( 'SIGINT', () => {
   process.exit();
 } );
 
-function instanceOfLogger ( opts ) {
-  return new Logger( opts );
-}
-
 function instanceOfRealtime ( opts ) {
   return new RealTime( opts );
 }
@@ -290,7 +286,7 @@ function prettyDisplay ( data ) {
 }
 
 module.exports = {
-  logger: instanceOfLogger,
+  logger: Logger,
   realtime: instanceOfRealtime,
   prettyDisplay
 };

--- a/test/loggerSpec.js
+++ b/test/loggerSpec.js
@@ -58,7 +58,7 @@ describe( 'Testing Logger API', () => {
     requestTTL: 5000
   };
 
-  let logger = index.logger( loggerConfig );
+  let logger = new index.logger( loggerConfig );
 
   it( 'should support chaining for non-returning methods', function() {
     logger


### PR DESCRIPTION
- instantiation of new logger object by calling new index.logger(opts) for example
